### PR TITLE
Add minimal docs and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# ClipJar
+CLI pipeline to generate short vertical videos from text scripts.
+
+## Installation
+```bash
+git clone <repo-url>
+cd ClipJar.io
+pip install -r requirements.txt
+```
+
+## Usage
+```bash
+python cli.py --script-file my_story.txt --output result.mp4
+```
+
+## Configuration
+Edit `config/config.json` or copy `config/config.example.json`.
+Set API keys in `.env` and place background videos in `assets/backgrounds`.
+
+## Contributing
+Fork the repository and submit pull requests. Run `pytest` before committing.

--- a/cli.py
+++ b/cli.py
@@ -13,8 +13,10 @@ except Exception:  # pragma: no cover - missing dependency
 
 
 class CLI:
+    """Command-line interface for the ClipJar pipeline."""
     @staticmethod
     def build_parser() -> argparse.ArgumentParser:
+        """Return the argument parser for the CLI."""
         parser = argparse.ArgumentParser(description="Video generation pipeline")
         parser.add_argument(
             "--version",
@@ -56,6 +58,7 @@ class CLI:
 
     @staticmethod
     def parse(args=None) -> argparse.Namespace:
+        """Parse command line *args* or ``sys.argv`` when ``None``."""
         parser = CLI.build_parser()
         return parser.parse_args(args)
 
@@ -80,6 +83,7 @@ def _read_script(args: argparse.Namespace) -> tuple[str, str]:
 
 
 def main(argv=None) -> None:
+    """Entry point for the ClipJar CLI."""
     from pipeline.pipeline import VideoPipeline
     from pipeline.logger import setup_logger
     from pipeline.helpers import color_print, log_trace, validate_files

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -10,6 +10,7 @@
   "background_videos_path": "assets/backgrounds",
   "resolution": "1080x1920",
   "ffmpeg_path": "ffmpeg",
+  "log_file": "./logs/clipjar.log",
   "step_timeout": 120,
   "safe_mode": false,
   "developer_mode": false,

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -10,6 +10,7 @@ import os
 
 @dataclass
 class Config:
+    """Application configuration loaded from ``config.json``."""
     subtitle_style: str = "simple"
     watermark_path: str | None = None
     watermark_opacity: float = 1.0
@@ -21,6 +22,7 @@ class Config:
     background_videos_path: str = "assets/backgrounds"
     resolution: str = "1080x1920"
     ffmpeg_path: str = "ffmpeg"
+    log_file: str = "./logs/clipjar.log"
     step_timeout: int = 120
     safe_mode: bool = False
     developer_mode: bool = False

--- a/pipeline/downloader.py
+++ b/pipeline/downloader.py
@@ -12,7 +12,9 @@ from .helpers import sanitize_name
 
 
 class Downloader:
+    """Small wrapper around ``yt_dlp`` for downloading media."""
     def __init__(self, output_dir: Path, log_file: Path | None = None, debug: bool = False) -> None:
+        """Create a downloader writing files to *output_dir*."""
         self.output_dir = output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.logger = setup_logger("downloader", log_file, debug)
@@ -33,6 +35,7 @@ class Downloader:
         self.logger.info(f"Downloaded {url}")
 
     def download_batch(self, urls: List[str], quality: str = "best", audio_only: bool = False) -> None:
+        """Download a list of *urls* concurrently."""
         futs = [self.executor.submit(self._download, u.strip(), quality, audio_only) for u in urls if u.strip()]
         for f in futs:
             f.result()

--- a/pipeline/helpers.py
+++ b/pipeline/helpers.py
@@ -86,6 +86,7 @@ def create_dummy_subtitles(path: Path) -> None:
 
 @dataclass
 class PipelineContext:
+    """Runtime information and output paths for a pipeline run."""
     script_text: str
     script_name: str
     output_dir: Path

--- a/pipeline/logger.py
+++ b/pipeline/logger.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 
 def setup_logger(name: str, log_file: Path | None = None, debug: bool = False) -> logging.Logger:
+    """Return a configured logger writing to console and optional *log_file*."""
     logger = logging.getLogger(name)
     level = logging.DEBUG if debug else logging.INFO
     logger.setLevel(level)

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -20,35 +20,39 @@ from .config import Config
 
 
 class VideoPipeline:
+    """Orchestrates the voiceover, subtitles and rendering steps."""
+
     def __init__(self, config: Config, debug: bool = False, log_file: Path | None = None):
         self.config = config
+        log_file = Path(log_file or config.log_file)
+        log_file.parent.mkdir(parents=True, exist_ok=True)
         self.logger = setup_logger("pipeline", log_file, debug)
         self.debug = debug
         self.log_file = log_file
         self.timeout = config.step_timeout
 
-    def run(
+    # ------------------------------------------------------------------
+    # private helpers
+    # ------------------------------------------------------------------
+
+    def _setup_context(
         self,
         script_text: str,
         script_name: str,
-        background: str | None = None,
-        output: Path | None = None,
-        force_coqui: bool = False,
-        whisper_disable: bool = False,
-        no_subtitles: bool = False,
-        intro: Path | None = None,
-        outro: Path | None = None,
-        trim_silence: bool = False,
-        crop_safe: bool = False,
-        summary_overlay: bool = False,
-    ) -> PipelineContext:
+        background: str | None,
+        output: Path | None,
+        force_coqui: bool,
+    ) -> tuple[PipelineContext, Path]:
+        """Validate config and return a context and background folder."""
+
+        self.config.validate(self.logger)
+
         style = self.config.subtitle_style
         engine = self.config.voice_engine
         voice_id = self.config.default_voice_id
         if force_coqui:
             engine = "coqui"
 
-        # resolve background folder
         bg_styles = self.config.background_styles or {}
         bg_folder = Path(self.config.background_videos_path)
         if background:
@@ -78,109 +82,136 @@ class VideoPipeline:
         )
         ctx.final_video_path = final_output
 
-        # Reconfigure logger to use session log as well
         setup_logger("pipeline", session_log, self.debug)
-        self.logger.info("Starting pipeline")
-        status = "success"
-        start = time.time()
+        return ctx, bg_folder
+
+    def _download_media(self, ctx: PipelineContext) -> None:
+        """Download any required media assets.
+
+        Currently a no-op placeholder that can be extended to pull remote
+        resources using :class:`Downloader`.
+        """
+
+        # Intentionally left blank - to be implemented as needed
+        return None
+
+    def _generate_voiceover(self, ctx: PipelineContext, force_coqui: bool, trim_silence: bool) -> None:
+        """Generate the voiceover audio file for *ctx*."""
+
+        self.logger.info("[1/3] Voiceover generation")
+        voice = VoiceOverGenerator(
+            ctx.voice_engine,
+            ctx.voice_id,
+            self.config.coqui_model_name,
+            force_coqui=force_coqui,
+            debug=self.debug,
+            log_file=ctx.log_file,
+        )
         try:
-            self.logger.info("[1/3] Voiceover generation")
-            # Voiceover
-            voice = VoiceOverGenerator(
-                engine,
-                voice_id,
-                self.config.coqui_model_name,
-                force_coqui=force_coqui,
-                debug=self.debug,
-                log_file=session_log,
-            )
-            try:
-                run_with_timeout(
-                    lambda: voice.generate(ctx.script_text, ctx.voiceover_path),
-                    self.timeout,
-                )
-                if not ctx.voiceover_path.exists() or ctx.voiceover_path.stat().st_size == 0:
-                    raise RuntimeError("voiceover file invalid")
-            except Exception as e:
-                self.logger.error(f"Voiceover step failed: {e}")
-                if self.config.developer_mode:
-                    create_silence(ctx.voiceover_path)
-                    self.logger.warning("Developer mode: using silent audio")
-                else:
-                    raise
-            if trim_silence:
-                self.logger.info("Trimming silence from voiceover")
-                try:
-                    from .helpers import trim_silence_ffmpeg
-
-                    trim_silence_ffmpeg(ctx.voiceover_path, self.config.ffmpeg_path)
-                except Exception as e:
-                    self.logger.warning(f"trim_silence failed: {e}")
-
-            if not no_subtitles:
-                self.logger.info("[2/3] Generating subtitles")
-                subs = SubtitleGenerator(
-                    style, model=self.config.whisper_model, log_file=session_log, debug=self.debug
-                )
-                try:
-                    if whisper_disable:
-                        self.logger.info("Whisper disabled; generating basic subtitles")
-                        words = [
-                            {"start": i * 0.5, "end": (i + 1) * 0.5, "text": w}
-                            for i, w in enumerate(script_text.split())
-                        ]
-                    else:
-                        words = run_with_timeout(subs.transcribe, self.timeout, ctx.voiceover_path)
-                    run_with_timeout(subs.generate_ass, self.timeout, words, ctx.subtitles_path)
-                except Exception as e:
-                    self.logger.error(f"Subtitle step failed: {e}")
-                    if self.config.developer_mode:
-                        create_dummy_subtitles(ctx.subtitles_path)
-                        self.logger.warning("Developer mode: using dummy subtitles")
-                    else:
-                        raise
-            else:
-                ctx.subtitles_path = ctx.output_dir / "subtitles.ass"
-                ctx.subtitles_path.write_text("")
-                self.logger.info("Subtitles disabled")
-
-            self.logger.info("[3/3] Rendering video")
-            # Render
-            watermark_path = (
-                Path(self.config.watermark_path)
-                if self.config.watermark_enabled and self.config.watermark_path
-                else None
-            )
-            renderer = VideoRenderer(
-                bg_folder,
-                watermark_path,
-                self.config.watermark_opacity,
-                resolution=self.config.resolution,
-                ffmpeg_path=self.config.ffmpeg_path,
-                log_file=session_log,
-                debug=self.debug,
-            )
             run_with_timeout(
-                renderer.render,
+                lambda: voice.generate(ctx.script_text, ctx.voiceover_path),
                 self.timeout,
-                ctx.voiceover_path,
-                None if no_subtitles else ctx.subtitles_path,
-                ctx.final_video_path,
-                intro,
-                outro,
-                crop_safe=crop_safe,
-                overlay_text=script_name if summary_overlay else None,
             )
+            if not ctx.voiceover_path.exists() or ctx.voiceover_path.stat().st_size == 0:
+                raise RuntimeError("voiceover file invalid")
         except Exception as e:
-            status = "failed"
-            self.logger.error(f"Pipeline failed: {e}")
-            ctx.write_error_trace(e)
-            log_trace(e)
-            ctx.save_metadata(status=status)
-            ctx.save_config_snapshot(self.config.__dict__)
-            ctx.write_summary()
-            ctx.archive()
-            raise
+            self.logger.error(f"Voiceover step failed: {e}")
+            if self.config.developer_mode:
+                create_silence(ctx.voiceover_path)
+                self.logger.warning("Developer mode: using silent audio")
+            else:
+                raise
+
+        if trim_silence:
+            self.logger.info("Trimming silence from voiceover")
+            try:
+                from .helpers import trim_silence_ffmpeg
+
+                trim_silence_ffmpeg(ctx.voiceover_path, self.config.ffmpeg_path)
+            except Exception as e:  # pragma: no cover - runtime warnings
+                self.logger.warning(f"trim_silence failed: {e}")
+
+    def _generate_subtitles(
+        self,
+        ctx: PipelineContext,
+        script_text: str,
+        whisper_disable: bool,
+        no_subtitles: bool,
+    ) -> None:
+        """Create subtitles for the video if enabled."""
+
+        if no_subtitles:
+            ctx.subtitles_path = ctx.output_dir / "subtitles.ass"
+            ctx.subtitles_path.write_text("")
+            self.logger.info("Subtitles disabled")
+            return
+
+        self.logger.info("[2/3] Generating subtitles")
+        subs = SubtitleGenerator(
+            ctx.subtitle_style,
+            model=self.config.whisper_model,
+            log_file=ctx.log_file,
+            debug=self.debug,
+        )
+        try:
+            if whisper_disable:
+                self.logger.info("Whisper disabled; generating basic subtitles")
+                words = [
+                    {"start": i * 0.5, "end": (i + 1) * 0.5, "text": w}
+                    for i, w in enumerate(script_text.split())
+                ]
+            else:
+                words = run_with_timeout(subs.transcribe, self.timeout, ctx.voiceover_path)
+            run_with_timeout(subs.generate_ass, self.timeout, words, ctx.subtitles_path)
+        except Exception as e:
+            self.logger.error(f"Subtitle step failed: {e}")
+            if self.config.developer_mode:
+                create_dummy_subtitles(ctx.subtitles_path)
+                self.logger.warning("Developer mode: using dummy subtitles")
+            else:
+                raise
+
+    def _render_video(
+        self,
+        ctx: PipelineContext,
+        bg_folder: Path,
+        intro: Path | None,
+        outro: Path | None,
+        no_subtitles: bool,
+        crop_safe: bool,
+        summary_overlay: bool,
+    ) -> None:
+        """Render the final video using FFmpeg."""
+
+        self.logger.info("[3/3] Rendering video")
+        watermark_path = (
+            Path(self.config.watermark_path)
+            if self.config.watermark_enabled and self.config.watermark_path
+            else None
+        )
+        renderer = VideoRenderer(
+            bg_folder,
+            watermark_path,
+            self.config.watermark_opacity,
+            resolution=self.config.resolution,
+            ffmpeg_path=self.config.ffmpeg_path,
+            log_file=ctx.log_file,
+            debug=self.debug,
+        )
+        run_with_timeout(
+            renderer.render,
+            self.timeout,
+            ctx.voiceover_path,
+            None if no_subtitles else ctx.subtitles_path,
+            ctx.final_video_path,
+            intro,
+            outro,
+            crop_safe=crop_safe,
+            overlay_text=ctx.script_name if summary_overlay else None,
+        )
+
+    def _archive_outputs(self, ctx: PipelineContext, status: str, start: float) -> None:
+        """Write session metadata and archive outputs."""
 
         duration = f"{int(time.time() - start)}s"
         ctx.save_metadata(status=status)
@@ -196,5 +227,55 @@ class VideoPipeline:
         ctx.save_config_snapshot(self.config.__dict__)
         ctx.write_summary()
         ctx.archive()
+
+    def run(
+        self,
+        script_text: str,
+        script_name: str,
+        background: str | None = None,
+        output: Path | None = None,
+        force_coqui: bool = False,
+        whisper_disable: bool = False,
+        no_subtitles: bool = False,
+        intro: Path | None = None,
+        outro: Path | None = None,
+        trim_silence: bool = False,
+        crop_safe: bool = False,
+        summary_overlay: bool = False,
+    ) -> PipelineContext:
+        """Run the pipeline and return a :class:`PipelineContext`."""
+
+        status = "success"
+        ctx: PipelineContext | None = None
+        start = time.time()
+        try:
+            ctx, bg_folder = self._setup_context(
+                script_text, script_name, background, output, force_coqui
+            )
+            self.logger.info("Starting pipeline")
+
+            self._download_media(ctx)
+            self._generate_voiceover(ctx, force_coqui, trim_silence)
+            self._generate_subtitles(ctx, script_text, whisper_disable, no_subtitles)
+            self._render_video(
+                ctx,
+                bg_folder,
+                intro,
+                outro,
+                no_subtitles,
+                crop_safe,
+                summary_overlay,
+            )
+        except Exception as e:
+            status = "failed"
+            self.logger.error(f"Pipeline failed: {e}")
+            if ctx:
+                ctx.write_error_trace(e)
+            log_trace(e)
+            raise
+        finally:
+            if ctx:
+                self._archive_outputs(ctx, status, start)
+
         self.logger.info(f"Pipeline completed. Video at {ctx.final_video_path}")
         return ctx

--- a/pipeline/subtitles.py
+++ b/pipeline/subtitles.py
@@ -9,6 +9,7 @@ from .helpers import create_dummy_subtitles
 
 
 class SubtitleGenerator:
+    """Generate subtitles using Whisper and export to ASS format."""
     def __init__(self, style: str, model: str = "base", log_file: Optional[Path] = None, debug: bool = False):
         self.style = style
         self.model_name = model

--- a/pipeline/voiceover.py
+++ b/pipeline/voiceover.py
@@ -18,6 +18,7 @@ load_dotenv()
 
 
 class VoiceOverGenerator:
+    """Create voiceovers via ElevenLabs or Coqui TTS."""
     def __init__(
         self,
         engine: str,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-python-dotenv
-requests
-whisper
-TTS
-PySide6
-yt_dlp
-python-docx
+python-dotenv==1.1.0
+requests==2.32.4
+whisper==1.1.10
+TTS==0.22.0
+yt_dlp==2025.6.9

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,8 @@
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+def test_pipeline_import():
+    assert importlib.import_module('pipeline.pipeline')


### PR DESCRIPTION
## Summary
- pin Python dependencies and drop unused ones
- create project README
- add pytest scaffold with smoke test
- document CLI and pipeline classes
- refactor rendering temp files
- enable file logging via config
- refactor pipeline runner into smaller methods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855bdf22e488329b8ca3c9f19949732